### PR TITLE
Resolvendo o Erro de Execução da nativa 00000000ff7f66ab

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -37,16 +37,21 @@ local admim= {}
 -- Esse loop cria um array (table) com as informações de ids - Se fizer direto no loop do DRAWTEXT ele tem um delay ao mostrar o id (fica piscando)
 -----------------------------------------------------------------------------------------------------------------------------------------
 Citizen.CreateThread(
-	function()
-		while true do
-			Citizen.Wait(1000)
-		    for _, id in ipairs(GetActivePlayers()) do
-				local pid = SVIDclient.getId(GetPlayerServerId(id))
-				players[id] = pid
-				admim = SVIDclient.getPermissao() 
-			end
-		end
-	end
+    function()
+        while true do
+            Citizen.Wait(1000)
+
+            for id = 0, 255 do 
+                if NetworkIsPlayerActive(id) then
+                    if GetPlayerPed(id) ~= PlayerId() then           
+                        local pid = SVIDclient.getId(GetPlayerServerId(id))
+                        players[id] = pid
+                        admim = SVIDclient.getPermissao()
+                    end
+                end
+            end
+        end
+    end
 )
 -----------------------------------------------------------------------------------------------------------------------------------------
 -- Esse Loop Print os ID's na Cabeça


### PR DESCRIPTION
Mudei o loop, porque da forma que estava antes o GetActivePlayers retornava um nil aleatório dependendo da carga do servidor

Desta forma que esta é a única forma que consegui fazer funcionar pra mim

Mudei o GetPlayerPed(-1) pq vi no fórum acho uma vez que o PlayerId() é mais rápido